### PR TITLE
[fire-core][2021年6月8日] 修复flink任务无法进行参数覆盖的bug

### DIFF
--- a/fire-engines/fire-flink/src/main/java/org/apache/flink/configuration/GlobalConfiguration.java
+++ b/fire-engines/fire-flink/src/main/java/org/apache/flink/configuration/GlobalConfiguration.java
@@ -316,7 +316,7 @@ public final class GlobalConfiguration {
         Preconditions.checkNotNull(key, "key is null");
         final String keyInLower = key.toLowerCase();
         // 二次开发代码，用于隐藏webui中敏感信息
-        String hideKeys = JavaConversions.mapAsJavaMap(PropUtils.settings()).getOrDefault("spark.fire.conf.print.blacklist", "password,secret,fs.azure.account.key");
+        String hideKeys = JavaConversions.mapAsJavaMap(PropUtils.settings()).getOrDefault("fire.conf.print.blacklist", "password,secret,fs.azure.account.key");
         if (hideKeys != null && hideKeys.length() > 0) {
             String[] hideKeyArr = hideKeys.split(",");
             for (String hideKey : hideKeyArr) {

--- a/fire-examples/spark-examples/src/main/scala/com/zto/fire/examples/spark/streaming/KafkaTest.scala
+++ b/fire-examples/spark-examples/src/main/scala/com/zto/fire/examples/spark/streaming/KafkaTest.scala
@@ -78,7 +78,7 @@ object KafkaTest extends BaseSparkStreaming {
   @Scheduled(fixedInterval = 60 * 1000, scope = "all")
   def loadTable: Unit = {
     println(s"${DateFormatUtils.formatCurrentDateTime()}=================== 每分钟执行loadTable ===================")
-    this.conf.settingsMap.foreach(conf => println(conf._1 + " -> " + conf._2))
+    this.conf.settings.foreach(conf => println(conf._1 + " -> " + conf._2))
   }
 
   @Scheduled(cron = "0 0 * * * ?")


### PR DESCRIPTION
修复flink任务无法生效非flink.开头的配置信息，如：taskmanager.memory.managed.fraction